### PR TITLE
WIP: Fleet plugins gracefully handle fleet deletion

### DIFF
--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -850,8 +850,16 @@ static flb_sds_t get_project_id_from_api_key(struct flb_in_calyptia_fleet_config
     return parse_api_key_json(ctx, (char *)token, tlen);
 }
 
+/**
+ * Perform an HTTP GET against the url.
+ * A client for the request is returned if the request was successful.
+ * The caller is responsible for destroying the client.
+ * If http_status_out is not NULL and a response was received from the server,
+ * the HTTP status code is stored there.
+ */
 static struct flb_http_client *fleet_http_do(struct flb_in_calyptia_fleet_config *ctx,
-                                             flb_sds_t url)
+                                             flb_sds_t url,
+                                             int *http_status_out)
 {
     int ret = -1;
     size_t b_sent;
@@ -896,6 +904,9 @@ static struct flb_http_client *fleet_http_do(struct flb_in_calyptia_fleet_config
         goto http_do_error;
     }
 
+    if (http_status_out != NULL) {
+        *http_status_out = client->resp.status;
+    }
     if (client->resp.status != 200) {
         flb_plg_error(ctx->ins, "search http status code error: %d", client->resp.status);
         goto http_do_error;
@@ -941,7 +952,7 @@ static int get_calyptia_fleet_id_by_name(struct flb_in_calyptia_fleet_config *ct
     flb_sds_printf(&url, CALYPTIA_ENDPOINT_FLEET_BY_NAME,
                    project_id, ctx->fleet_name);
 
-    client = fleet_http_do(ctx, url);
+    client = fleet_http_do(ctx, url, NULL);
     flb_sds_destroy(url);
 
     if (!client) {
@@ -951,6 +962,7 @@ static int get_calyptia_fleet_id_by_name(struct flb_in_calyptia_fleet_config *ct
 
     if (parse_fleet_search_json(ctx, client->resp.payload, client->resp.payload_size) == -1) {
         flb_plg_error(ctx->ins, "unable to find fleet: %s", ctx->fleet_name);
+        ctx->fleet_deleted = FLB_TRUE;
         flb_http_client_destroy(client);
         flb_sds_destroy(project_id);
         return -1;
@@ -970,7 +982,8 @@ static int get_calyptia_file(struct flb_in_calyptia_fleet_config *ctx,
                              flb_sds_t url,
                              const char *hdr,
                              const char *dst,
-                             time_t *time_last_modified)
+                             time_t *time_last_modified,
+                             int *get_http_status_out)
 {
     struct flb_http_client *client;
     size_t len;
@@ -986,7 +999,7 @@ static int get_calyptia_file(struct flb_in_calyptia_fleet_config *ctx,
         return -1;
     }
 
-    client = fleet_http_do(ctx, url);
+    client = fleet_http_do(ctx, url, get_http_status_out);
     if (client == NULL) {
         return -1;
     }
@@ -1791,6 +1804,7 @@ int get_calyptia_fleet_config(struct flb_in_calyptia_fleet_config *ctx)
     flb_sds_t hdrname;
     time_t time_last_modified;
     int ret = -1;
+    int http_status = 0;
 
     if (ctx->fleet_url == NULL) {
         ctx->fleet_url = flb_sds_create_size(CALYPTIA_MAX_DIR_SIZE);
@@ -1830,8 +1844,16 @@ int get_calyptia_fleet_config(struct flb_in_calyptia_fleet_config *ctx)
     flb_sds_destroy(hdrname);
 
     /* create the base file. */
-    ret = get_calyptia_file(ctx, ctx->fleet_url, header, NULL, &time_last_modified);
+    ret = get_calyptia_file(ctx, ctx->fleet_url, header, NULL, &time_last_modified, &http_status);
     flb_sds_destroy(header);
+
+    /* Handle the fleet not existing */
+    if (http_status == 404) {
+        flb_plg_error(ctx->ins, "fleet no longer exists, fleet_id: %s",
+                     ctx->fleet_id ? ctx->fleet_id : "unknown");
+        ctx->fleet_deleted = FLB_TRUE;
+        return -1;
+    }
 
     /* new file created! */
     if (ret == 1) {
@@ -1886,6 +1908,12 @@ static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
 {
     int ret = -1;
     struct flb_in_calyptia_fleet_config *ctx = in_context;
+
+    /* If fleet was deleted, do not attempt to get config */
+    if (ctx->fleet_deleted) {
+        flb_plg_debug(ctx->ins, "fleet collection skipped since fleet no longer exists");
+        FLB_INPUT_RETURN(1); // return 0?
+    }
 
     if (ctx->fleet_id == NULL) {
         if (get_calyptia_fleet_id_by_name(ctx, config) == -1) {
@@ -2171,7 +2199,7 @@ static int get_calyptia_files(struct flb_in_calyptia_fleet_config *ctx,
         return -1;
     }
 
-    client = fleet_http_do(ctx, ctx->fleet_files_url);
+    client = fleet_http_do(ctx, ctx->fleet_files_url, NULL);
     if (client == NULL) {
         return -1;
     }
@@ -2217,6 +2245,7 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
     ctx->ins = in;
     ctx->collect_fd = -1;
     ctx->fleet_id_found = FLB_FALSE;
+    ctx->fleet_deleted = FLB_FALSE;
     ctx->config_timestamp = -1;
 
     /* Load the config map */

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.h
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.h
@@ -45,6 +45,9 @@ struct flb_in_calyptia_fleet_config {
     /* flag used to mark fleet_id for release when found automatically. */
     int fleet_id_found;
 
+    /* flag to indicate fleet no longer exists */
+    int fleet_deleted;
+
     flb_sds_t fleet_name;
     flb_sds_t machine_id;
     flb_sds_t config_dir;

--- a/plugins/out_calyptia/calyptia.c
+++ b/plugins/out_calyptia/calyptia.c
@@ -703,6 +703,9 @@ static int api_agent_create(struct flb_config *config, struct flb_calyptia *ctx)
             flb_plg_info(ctx->ins, "known agent registration successful");
         }
     }
+    else if (c->resp.status == 404) {
+        ctx->fleet_deleted = FLB_TRUE;
+    }
 
     /* release resources */
     flb_sds_destroy(meta);
@@ -751,6 +754,8 @@ static struct flb_calyptia *config_init(struct flb_output_instance *ins,
         return NULL;
     }
 #endif
+
+    ctx->fleet_deleted = FLB_FALSE;
 
     /* api_key */
     if (!ctx->api_key) {
@@ -855,6 +860,10 @@ static int cb_calyptia_init(struct flb_output_instance *ins,
         flb_plg_error(ins, "agent registration failed and register_retry_on_flush=false");
         return -1;
     }
+    else if (ret != FLB_OK && ctx->fleet_deleted == FLB_TRUE) {
+        flb_plg_error(ins, "agent registration failed due to fleet not existing");
+        return -1;
+    }
 
     return 0;
 }
@@ -940,6 +949,11 @@ static void cb_calyptia_flush(struct flb_event_chunk *event_chunk,
     (void) i_ins;
     (void) config;
 
+    if (ctx->fleet_deleted == FLB_TRUE) {
+        flb_plg_debug(ctx->ins, "fleet flush skipped since fleet no longer exists");
+        FLB_OUTPUT_RETURN(FLB_ERROR);
+    }
+
     if ((!ctx->agent_id || !ctx->agent_token) && ctx->register_retry_on_flush) {
         flb_plg_info(ctx->ins, "missing agent_id or agent_token, attempting re-registration register_retry_on_flush=true");
         if (register_agent(ctx, config) != FLB_OK) {
@@ -1001,6 +1015,18 @@ static void cb_calyptia_flush(struct flb_event_chunk *event_chunk,
         ret = calyptia_http_do(ctx, c, CALYPTIA_ACTION_METRICS);
         if (ret == FLB_OK) {
             flb_plg_debug(ctx->ins, "metrics delivered OK");
+        }
+        else if (c->resp.status == 404 || c->resp.status == 403) {
+            /* If the fleet is deleted, we should not retry */
+            ctx->fleet_deleted = FLB_TRUE;
+            flb_plg_error(ctx->ins, "fleet no longer exists, fleet_id: %s",
+                          ctx->fleet_id ? ctx->fleet_id : "unknown");
+            FLB_OUTPUT_RETURN(FLB_ERROR);
+        }
+        else if (c->resp.status == 422) {
+            flb_plg_error(ctx->ins, "invalid metrics payload");
+            debug_payload(ctx, out_buf, out_size);
+            FLB_OUTPUT_RETURN(FLB_ERROR);
         }
         else {
             flb_plg_error(ctx->ins, "could not deliver metrics");

--- a/plugins/out_calyptia/calyptia.h
+++ b/plugins/out_calyptia/calyptia.h
@@ -42,6 +42,7 @@ struct flb_calyptia {
     flb_sds_t agent_token;
     flb_sds_t machine_id;                 /* machine-id  */
     flb_sds_t fleet_id;                   /* fleet-id  */
+    int fleet_deleted;                    /* fleet was deleted */
     flb_sds_t metrics_endpoint;           /* metrics endpoint */
     struct flb_fstore *fs;                /* fstore ctx */
     struct flb_fstore_stream *fs_stream;  /* fstore stream */


### PR DESCRIPTION
This is WIP.

A fluent-bit process running as a fleet agent can encounter the case of the fleet having been deleted server-side. When this happens today, the agent sees the following behavior:
* The calyptia input plugin that polls for new config at a regular interval will encounter 404s. This logs errors and keeps the current config. The plugin will check again at the next interval.
	* Example:
```
[2025-06-26T00:28:27.305Z] "GET /v1/fleets/5e3b9ca5-1316-4991-b596-0c73fd17c2a2/config?format=ini&config_format=ini HTTP/1.1" 404 0 27 1ms "-"
```
* The calyptia output plugin that flushes agent metrics to the server at a regular interval will encounter 403 and 404 errors.
	* Example:
```[2025-06-26T00:28:32.306Z] "POST /v1/agents/33bea004-eac8-44fe-bbad-a4a51deef8dd/metrics HTTP/1.1" 403 8311 35 1ms "-"
[2025-06-26T00:28:53.309Z] "POST /v1/agents HTTP/1.1" 404 1232 27 5ms "-"
```


This PR changes the behavior of the agent when a fleet is deleted:
1. Agents that are running when the fleet gets deleted will stop checking for new configs and stop pushing metrics. They will keep running with last successfully fetched fleet config.
2. Agents that start up and reference a deleted/nonexistent fleet will only check for the fleet once. If the fleet does not exist, it will not continue checking. The last successfully fetched fleet config will be used if there is one.