### PR TITLE
in_calyptia_fleet: new fleet configs not marked current until successful reload

### DIFF
--- a/include/fluent-bit/flb_config.h
+++ b/include/fluent-bit/flb_config.h
@@ -286,6 +286,7 @@ struct flb_config {
     unsigned int hot_reloaded_count;
     int shutdown_by_hot_reloading;
     int hot_reloading;
+    int hot_reload_succeeded;
 
     /* Routing */
     size_t route_mask_size;

--- a/plugins/in_calyptia_fleet/in_calyptia_fleet.c
+++ b/plugins/in_calyptia_fleet/in_calyptia_fleet.c
@@ -232,7 +232,7 @@ static flb_sds_t time_fleet_config_filename(struct flb_in_calyptia_fleet_config 
 {
     char s_last_modified[32];
 
-    snprintf(s_last_modified, sizeof(s_last_modified)-1, "%d", (int)t);
+    snprintf(s_last_modified, sizeof(s_last_modified), "%d", (int)t);
     return fleet_config_filename(ctx, s_last_modified);
 }
 
@@ -470,53 +470,21 @@ static void *do_reload(void *data)
     /* avoid reloading the current configuration... just use our new one! */
     flb_context_set(reload->flb);
     reload->flb->config->enable_hot_reload = FLB_TRUE;
+    reload->flb->config->hot_reload_succeeded = FLB_FALSE;
     if (reload->flb->config->conf_path_file) {
         flb_sds_destroy(reload->flb->config->conf_path_file);
     }
     reload->flb->config->conf_path_file = reload->cfg_path;
 
-    flb_free(reload);
     sleep(5);
+    flb_info("reloading configuration from path: %s", reload->cfg_path);
+    flb_free(reload);
 #ifndef FLB_SYSTEM_WINDOWS
     kill(getpid(), SIGHUP);
 #else
     GenerateConsoleCtrlEvent(1 /* CTRL_BREAK_EVENT_1 */, 0);
 #endif
     return NULL;
-}
-
-static int test_config_is_valid(struct flb_in_calyptia_fleet_config *ctx,
-                                flb_sds_t cfgpath)
-{
-    return FLB_TRUE;
-    struct flb_cf *conf;
-    int ret = FLB_FALSE;
-
-    if (cfgpath == NULL) {
-        return FLB_FALSE;
-    }
-
-    conf = flb_cf_create();
-    if (conf == NULL) {
-        flb_plg_debug(ctx->ins, "unable to create config during validation test: %s",
-                      cfgpath);
-        goto config_init_error;
-    }
-
-    conf = flb_cf_create_from_file(conf, cfgpath);
-    if (conf == NULL) {
-        flb_plg_debug(ctx->ins,
-                      "unable to create config from file during validation test: %s",
-                      cfgpath);
-        goto cf_create_from_file_error;
-    }
-
-    ret = FLB_TRUE;
-
-cf_create_from_file_error:
-    flb_cf_destroy(conf);
-config_init_error:
-    return ret;
 }
 
 static int parse_config_name_timestamp(struct flb_in_calyptia_fleet_config *ctx,
@@ -538,11 +506,11 @@ static int parse_config_name_timestamp(struct flb_in_calyptia_fleet_config *ctx,
 #ifndef FLB_SYSTEM_WINDOWS
     case FLB_TRUE:
 
-        len = readlink(cfgpath, realname, sizeof(realname));
-
-        if (len > sizeof(realname)) {
+        len = readlink(cfgpath, realname, sizeof(realname) - 1);
+        if (len == -1 || len >= sizeof(realname) - 1) {
             return FLB_FALSE;
         }
+        realname[len] = '\0';
         break;
 #endif /* FLB_SYSTEM_WINDOWS */
     case FLB_FALSE:
@@ -600,6 +568,11 @@ static int execute_reload(struct flb_in_calyptia_fleet_config *ctx, flb_sds_t cf
     }
 
     reload = flb_calloc(1, sizeof(struct reload_ctx));
+    if (reload == NULL) {
+        flb_sds_destroy(cfgpath);
+        return FLB_FALSE;
+    }
+
     reload->flb = flb;
     reload->cfg_path = cfgpath;
 
@@ -614,6 +587,7 @@ static int execute_reload(struct flb_in_calyptia_fleet_config *ctx, flb_sds_t cf
             flb_input_collector_resume(ctx->collect_fd, ctx->ins);
         }
 
+        flb_free(reload);
         flb_sds_destroy(cfgpath);
         return FLB_FALSE;
     }
@@ -623,17 +597,6 @@ static int execute_reload(struct flb_in_calyptia_fleet_config *ctx, flb_sds_t cf
      *    [error] [reload] given flb context is NULL
      */
     flb_plg_info(ctx->ins, "loading configuration from %s.", reload->cfg_path);
-
-    if (test_config_is_valid(ctx, reload->cfg_path) == FLB_FALSE) {
-        flb_plg_error(ctx->ins, "unable to load configuration.");
-
-        if (ctx->collect_fd > 0) {
-            flb_input_collector_resume(ctx->collect_fd, ctx->ins);
-        }
-
-        flb_sds_destroy(cfgpath);
-        return FLB_FALSE;
-    }
 
     if (fleet_cur_chdir(ctx) == -1) {
         flb_errno();
@@ -835,6 +798,13 @@ static flb_sds_t get_project_id_from_api_key(struct flb_in_calyptia_fleet_config
     }
 
     elen = api_token_sep-ctx->api_key;
+
+    /* Check for overflow before padding calculation */
+    if (elen > SIZE_MAX - 4) {
+        flb_plg_error(ctx->ins, "API Token length too large");
+        return NULL;
+    }
+
     elen = elen + (4 - (elen % 4));
 
     if (elen > sizeof(encoded)) {
@@ -1313,210 +1283,194 @@ static struct cfl_array *read_glob(const char *path)
 
 #endif
 
-static int cfl_array_qsort_conf_files(const void *arg_a, const void *arg_b)
+/**
+ * Deletes the directory at path and all the files in it.
+ * FLB_TRUE is returned if successful, otherwise FLB_FALSE.
+ */
+static int delete_dir(const char *path)
 {
-    struct cfl_variant *var_a = (struct cfl_variant *)*(void **)arg_a;
-    struct cfl_variant *var_b = (struct cfl_variant *)*(void **)arg_b;
-
-    if (var_a == NULL && var_b == NULL) {
-        return 0;
-    }
-    else if (var_a == NULL) {
-        return -1;
-    }
-    else if (var_b == NULL) {
-        return 1;
-    }
-    else if (var_a->type != CFL_VARIANT_STRING &&
-             var_b->type != CFL_VARIANT_STRING) {
-        return 0;
-    }
-    else if (var_a->type != CFL_VARIANT_STRING) {
-        return -1;
-    }
-    else if (var_b->type != CFL_VARIANT_STRING) {
-        return 1;
-    }
-
-    return strcmp(var_a->data.as_string, var_b->data.as_string);
-}
-
-static int calyptia_config_delete_old_dir(const char *cfgpath)
-{
-    flb_sds_t cfg_glob;
-    char *ext;
+    flb_sds_t glob_pattern;
     struct cfl_array *files;
+    struct stat st;
     int idx;
+    int ret = FLB_TRUE;
 
-    if (cfgpath == NULL) {
+    if (path == NULL) {
         return FLB_FALSE;
     }
 
-    ext = strrchr(cfgpath, '.');
-    if (ext == NULL) {
+    glob_pattern = flb_sds_create(path);
+    if (glob_pattern == NULL) {
         return FLB_FALSE;
     }
 
-    cfg_glob = flb_sds_create_len(cfgpath, ext - cfgpath);
-    if (cfg_glob == NULL) {
+    if (flb_sds_cat_safe(&glob_pattern, PATH_SEPARATOR "*", strlen(PATH_SEPARATOR "*")) != 0) {
+        flb_sds_destroy(glob_pattern);
         return FLB_FALSE;
     }
 
-    if (flb_sds_cat_safe(&cfg_glob, PATH_SEPARATOR "*", strlen(PATH_SEPARATOR "*")) != 0) {
-        flb_sds_destroy(cfg_glob);
-        return FLB_FALSE;
-    }
-
-    files = read_glob(cfg_glob);
+    files = read_glob(glob_pattern);
+    flb_sds_destroy(glob_pattern);
 
     if (files != NULL) {
         for (idx = 0; idx < ((ssize_t)files->entry_count); idx++) {
-                unlink(files->entries[idx]->data.as_string);
+            if (stat(files->entries[idx]->data.as_string, &st) == 0) {
+                if (S_ISDIR(st.st_mode)) {
+                    if (delete_dir(files->entries[idx]->data.as_string) != FLB_TRUE) {
+                        ret = FLB_FALSE;
+                    }
+                } else {
+                    if (unlink(files->entries[idx]->data.as_string) != 0) {
+                        ret = FLB_FALSE;
+                    }
+                }
+            } else {
+                ret = FLB_FALSE;
+            }
         }
+        cfl_array_destroy(files);
     }
 
-    /* attempt to delete the main directory */
-    ext = strrchr(cfg_glob, PATH_SEPARATOR[0]);
-    if (ext) {
-        *ext = '\0';
-        rmdir(cfg_glob);
+    if (rmdir(path) != 0) {
+        ret = FLB_FALSE;
     }
 
-    /* attempt to delete the main directory */
-    ext = strrchr(cfg_glob, '/');
-    if (ext) {
-        *ext = '\0';
-        rmdir(cfg_glob);
-    }
-
-    flb_sds_destroy(cfg_glob);
-    cfl_array_destroy(files);
-
-    return FLB_TRUE;
+    return ret;
 }
 
-static int calyptia_config_delete_old(struct flb_in_calyptia_fleet_config *ctx)
+/**
+ * Deletes config files and directories that are referenced (directly or
+ * indirectly) by the symlink at the value returned by the function pointed to
+ * by config_filename_func.
+ *
+ * Returns FLB_TRUE if successful, otherwise FLB_FALSE.
+ */
+static int calyptia_config_delete_by_symlink(struct flb_in_calyptia_fleet_config *ctx,
+                                             flb_sds_t (*config_filename_func)(struct flb_in_calyptia_fleet_config *))
 {
     struct cfl_array *confs;
-    struct cfl_array *tconfs;
     flb_sds_t glob_files = NULL;
+    flb_sds_t config_path = NULL;
     int idx;
+    char filename_prefix[32];
 
     if (ctx == NULL) {
-        return -1;
+        return FLB_FALSE;
     }
+
+    /* Get the symlink path and extract prefix from its target */
+    config_path = config_filename_func(ctx);
+    if (config_path == NULL) {
+        return FLB_FALSE;
+    }
+
+    /* Follow the symlink to get the target filename */
+    char realname[CALYPTIA_MAX_DIR_SIZE] = {0};
+    ssize_t len;
+
+    len = readlink(config_path, realname, sizeof(realname) - 1);
+    if (len == -1) {
+        flb_sds_destroy(config_path);
+        return FLB_FALSE;
+    }
+    realname[len] = '\0';
+
+    /* Extract filename without directory path */
+    char *filename = basename(realname);
+
+    /* Remove file extension to get the prefix */
+    char *ext = strrchr(filename, '.');
+    if (ext != NULL) {
+        *ext = '\0';
+    }
+
+    /* Copy the prefix for pattern matching */
+    strncpy(filename_prefix, filename, sizeof(filename_prefix) - 1);
+    filename_prefix[sizeof(filename_prefix) - 1] = '\0';
 
     if (generate_base_fleet_directory(ctx, &glob_files) == NULL) {
         flb_sds_destroy(glob_files);
-        return -1;
+        flb_sds_destroy(config_path);
+        return FLB_FALSE;
     }
 
-    if (ctx->fleet_config_legacy_format) {
-        if (flb_sds_cat_safe(&glob_files, PATH_SEPARATOR "*.conf", strlen(PATH_SEPARATOR "*.conf")) != 0) {
-            flb_sds_destroy(glob_files);
-            return -1;
-        }
-    } else if (flb_sds_cat_safe(&glob_files, PATH_SEPARATOR "*.yaml", strlen(PATH_SEPARATOR "*.yaml")) != 0) {
+    /* Create glob pattern for files starting with the prefix */
+    if (flb_sds_cat_safe(&glob_files, PATH_SEPARATOR, strlen(PATH_SEPARATOR)) != 0) {
         flb_sds_destroy(glob_files);
-        return -1;
+        flb_sds_destroy(config_path);
+        return FLB_FALSE;
+    }
+
+    if (flb_sds_cat_safe(&glob_files, filename_prefix, strlen(filename_prefix)) != 0) {
+        flb_sds_destroy(glob_files);
+        flb_sds_destroy(config_path);
+        return FLB_FALSE;
+    }
+
+    if (flb_sds_cat_safe(&glob_files, "*", 1) != 0) {
+        flb_sds_destroy(glob_files);
+        flb_sds_destroy(config_path);
+        return FLB_FALSE;
     }
 
     confs = read_glob(glob_files);
     if (confs == NULL) {
         flb_sds_destroy(glob_files);
-        return -1;
+        flb_sds_destroy(config_path);
+        return FLB_FALSE;
     }
 
-    tconfs = cfl_array_create(1);
-    if (tconfs == NULL) {
-        flb_sds_destroy(glob_files);
-        cfl_array_destroy(confs);
-        return -1;
-    }
-
-    if (cfl_array_resizable(tconfs, FLB_TRUE) != 0) {
-        flb_sds_destroy(glob_files);
-        cfl_array_destroy(confs);
-        return -1;
-    }
-
+    /* Delete all files and directories that match the prefix pattern */
     for (idx = 0; idx < confs->entry_count; idx++) {
-        if (fleet_config_path_timestamp(ctx, confs->entries[idx]->data.as_string) > 0) {
-            cfl_array_append_string(tconfs, confs->entries[idx]->data.as_string);
+        struct stat st;
+        const char *entry_path = confs->entries[idx]->data.as_string;
+
+        if (stat(entry_path, &st) == 0) {
+            if (S_ISDIR(st.st_mode)) {
+                flb_plg_info(ctx->ins, "deleting config directory: %s", entry_path);
+                if (delete_dir(entry_path) != 0) {
+                    flb_plg_warn(ctx->ins, "unable to delete config directory: %s", entry_path);
+                }
+            } else {
+                flb_plg_info(ctx->ins, "deleting config file: %s", entry_path);
+                if (unlink(entry_path) != 0) {
+                    flb_plg_warn(ctx->ins, "unable to delete config file: %s", entry_path);
+                }
+            }
         }
     }
 
-    qsort(tconfs->entries, tconfs->entry_count,
-          sizeof(struct cfl_variant *),
-          cfl_array_qsort_conf_files);
-
-    for (idx = 0; idx < (((ssize_t)tconfs->entry_count) -3); idx++) {
-        unlink(tconfs->entries[idx]->data.as_string);
-        calyptia_config_delete_old_dir(tconfs->entries[idx]->data.as_string);
+    flb_plg_info(ctx->ins, "deleting config symlink: %s", config_path);
+    if (unlink(config_path) != 0) {
+        flb_plg_warn(ctx->ins, "unable to delete config symlink: %s", config_path);
     }
 
     cfl_array_destroy(confs);
-    cfl_array_destroy(tconfs);
     flb_sds_destroy(glob_files);
+    flb_sds_destroy(config_path);
 
-    return 0;
+    return FLB_TRUE;
 }
 
-static flb_sds_t calyptia_config_get_newest(struct flb_in_calyptia_fleet_config *ctx)
+/* Wrapper functions for the macros to use as function pointers */
+static flb_sds_t new_fleet_config_filename_func(struct flb_in_calyptia_fleet_config *ctx)
 {
-    struct cfl_array *inis;
-    flb_sds_t glob_conf_files = NULL;
-    flb_sds_t cfgnewname = NULL;
-    const char *curconf;
-    int idx;
+    return new_fleet_config_filename(ctx);
+}
 
-    if (ctx == NULL) {
-        return NULL;
-    }
+static flb_sds_t old_fleet_config_filename_func(struct flb_in_calyptia_fleet_config *ctx)
+{
+    return old_fleet_config_filename(ctx);
+}
 
-    if (generate_base_fleet_directory(ctx, &glob_conf_files) == NULL) {
-        flb_plg_error(ctx->ins, "unable to generate fleet directory name");
-        flb_sds_destroy(glob_conf_files);
-        return NULL;
-    }
+static int calyptia_config_delete_new(struct flb_in_calyptia_fleet_config *ctx)
+{
+    return calyptia_config_delete_by_symlink(ctx, new_fleet_config_filename_func);
+}
 
-    if (ctx->fleet_config_legacy_format) {
-        if (flb_sds_cat_safe(&glob_conf_files, PATH_SEPARATOR "*.conf", strlen(PATH_SEPARATOR "*.conf")) != 0) {
-            flb_plg_error(ctx->ins, "unable to concatenate fleet glob");
-            flb_sds_destroy(glob_conf_files);
-            return NULL;
-        }
-    }
-    else if (flb_sds_cat_safe(&glob_conf_files, PATH_SEPARATOR "*.yaml", strlen(PATH_SEPARATOR "*.yaml")) != 0) {
-        flb_plg_error(ctx->ins, "unable to concatenate fleet glob");
-        flb_sds_destroy(glob_conf_files);
-        return NULL;
-    }
-
-    inis = read_glob(glob_conf_files);
-    if (inis == NULL) {
-        flb_plg_error(ctx->ins, "unable to read fleet directory for config files: %s",
-                      glob_conf_files);
-        flb_sds_destroy(glob_conf_files);
-        return NULL;
-    }
-
-    qsort(inis->entries, inis->entry_count,
-          sizeof(struct cfl_variant *),
-          cfl_array_qsort_conf_files);
-
-    for (idx = inis->entry_count-1; idx >= 0; idx--) {
-        curconf = inis->entries[idx]->data.as_string;
-        if (fleet_config_path_timestamp(ctx, curconf) > 0) {
-            cfgnewname = flb_sds_create(curconf);
-            break;
-        }
-    }
-
-    cfl_array_destroy(inis);
-    flb_sds_destroy(glob_conf_files);
-
-    return cfgnewname;
+static int calyptia_config_delete_old(struct flb_in_calyptia_fleet_config *ctx)
+{
+    return calyptia_config_delete_by_symlink(ctx, old_fleet_config_filename_func);
 }
 
 #ifndef FLB_SYSTEM_WINDOWS
@@ -1538,17 +1492,20 @@ static int calyptia_config_add(struct flb_in_calyptia_fleet_config *ctx,
         goto error;
     }
 
-    if (exists_new_fleet_config(ctx) == FLB_TRUE) {
-
-        if (rename(cfgnewname, cfgoldname)) {
-            goto error;
-        }
-    }
-    else if (exists_cur_fleet_config(ctx) == FLB_TRUE) {
-
+    if (exists_cur_fleet_config(ctx) == FLB_TRUE) {
         if (rename(cfgcurname, cfgoldname)) {
             goto error;
         }
+    }
+
+    /* If there is uncommitted new config, delete and replace it */
+    if (exists_new_fleet_config(ctx) == FLB_TRUE) {
+        flb_plg_warn(ctx->ins, "replacing uncommitted new config: %s", cfgnewname);
+        if (calyptia_config_delete_new(ctx) != FLB_TRUE) {
+            flb_plg_error(ctx->ins, "unable to delete uncommitted new config");
+            goto error;
+        }
+        flb_plg_warn(ctx->ins, "deleted uncommitted new config: %s", cfgnewname);
     }
 
     if (symlink(cfgname, cfgnewname)) {
@@ -1574,6 +1531,11 @@ error:
     return rc;
 }
 
+/**
+* Commits the latest received config as the valid, now-current config.
+* This updates the symlink to the current config file to point to the
+* new config file, and then deletes the old config file.
+*/
 static int calyptia_config_commit(struct flb_in_calyptia_fleet_config *ctx)
 {
     int rc = FLB_FALSE;
@@ -1601,8 +1563,13 @@ static int calyptia_config_commit(struct flb_in_calyptia_fleet_config *ctx)
         }
     }
 
-    calyptia_config_delete_old(ctx);
+    if (calyptia_config_delete_old(ctx) != FLB_TRUE) {
+        flb_plg_error(ctx->ins, "unable to delete old config");
+        goto error;
+    }
     rc = FLB_TRUE;
+
+    flb_plg_info(ctx->ins, "committed new config: %s", cfgcurname);
 
 error:
     if (cfgnewname) {
@@ -1681,6 +1648,51 @@ static int calyptia_config_rollback(struct flb_in_calyptia_fleet_config *ctx,
     return FLB_TRUE;
 }
 #endif
+
+
+/**
+* Checks if the last config was successfully reloaded and if so, commits it.
+* This considers a newly received config to be successfully reloaded if
+* the current context indicates it was loaded from the new config file.
+*
+* This returns 0 unless there was an error.
+*/
+static int commit_config_if_reloaded(struct flb_in_calyptia_fleet_config *ctx)
+{
+   struct flb_config *config;
+
+   /* Get the current configuration */
+   config = ctx->ins->config;
+   if (config == NULL) {
+       return 0;
+   }
+
+   if (config->hot_reloading == FLB_TRUE) {
+       return 0;
+   }
+
+   if (config->hot_reload_succeeded != FLB_TRUE) {
+       /* The config either hasn't been reloaded yet or the reload failed */
+       return 0;
+   }
+
+   /* Check if the current config is from a new fleet config file */
+   if (exists_new_fleet_config(ctx) == FLB_FALSE) {
+       return 0;
+   }
+
+   if (is_new_fleet_config(ctx, config)) {
+       /* The config was successfully reloaded from the new file, commit it */
+       if (calyptia_config_commit(ctx) == FLB_TRUE) {
+           flb_plg_info(ctx->ins, "committed reloaded configuration");
+       } else {
+           flb_plg_error(ctx->ins, "failed to commit reloaded configuration");
+           return -1;
+       }
+   }
+
+   return 0;
+}
 
 static void fleet_config_get_properties(flb_sds_t *buf, struct mk_list *props, int fleet_config_legacy_format)
 {
@@ -1979,6 +1991,12 @@ static int in_calyptia_fleet_collect(struct flb_input_instance *ins,
          }
     }
 
+    /* Update symlinks if a recent reload was successful */
+    ret = commit_config_if_reloaded(ctx);
+    if (ret == -1) {
+        goto fleet_id_error;
+    }
+
     ret = get_calyptia_fleet_config(ctx);
 
 fleet_id_error:
@@ -2076,7 +2094,6 @@ static int fleet_cur_chdir(struct flb_in_calyptia_fleet_config *ctx)
 static int load_fleet_config(struct flb_in_calyptia_fleet_config *ctx)
 {
     flb_ctx_t *flb_ctx = flb_context_get();
-    flb_sds_t cfgnewname = NULL;
 
     /* check if we are already using the fleet configuration file. */
     if (is_fleet_config(ctx, flb_ctx->config) == FLB_FALSE) {
@@ -2085,19 +2102,8 @@ static int load_fleet_config(struct flb_in_calyptia_fleet_config *ctx)
         if (exists_cur_fleet_config(ctx) == FLB_TRUE) {
             return execute_reload(ctx, cur_fleet_config_filename(ctx));
         }
-        else if (exists_new_fleet_config(ctx) == FLB_TRUE) {
-            return execute_reload(ctx, new_fleet_config_filename(ctx));
-        }
-        else {
-            cfgnewname = calyptia_config_get_newest(ctx);
-
-            if (cfgnewname != NULL) {
-                flb_plg_debug(ctx->ins, "loading newest configuration: %s", cfgnewname);
-                return execute_reload(ctx, cfgnewname);
-            }
-            else {
-                flb_plg_warn(ctx->ins, "unable to find latest configuration file");
-            }
+        if (exists_old_fleet_config(ctx) == FLB_TRUE) {
+            return execute_reload(ctx, old_fleet_config_filename(ctx));
         }
     }
     else {
@@ -2143,6 +2149,7 @@ static int create_fleet_file(flb_sds_t fleetdir,
 
     fp = fopen(fname, "w+");
     if (fp == NULL) {
+        flb_sds_destroy(fname);
         return -1;
     }
 
@@ -2281,6 +2288,7 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
     int upstream_flags;
     struct flb_in_calyptia_fleet_config *ctx;
     (void) data;
+    flb_sds_t cfgnewname;
 
 #ifdef _WIN32
     char *tmpdir;
@@ -2377,13 +2385,30 @@ static int in_calyptia_fleet_init(struct flb_input_instance *in,
         create_fleet_header(ctx);
     }
 
+
+    /* If there is an uncommitted new config, delete it */
+    if (exists_new_fleet_config(ctx) == FLB_TRUE && is_new_fleet_config(ctx, config) == FLB_FALSE) {
+        cfgnewname = new_fleet_config_filename(ctx);
+
+        if (cfgnewname == NULL) {
+            flb_plg_error(ctx->ins, "unable to create new config filename");
+            in_calyptia_fleet_destroy(ctx);
+            return -1;
+        }
+
+        flb_plg_warn(ctx->ins, "deleting uncommitted new config: %s", cfgnewname);
+        if (calyptia_config_delete_new(ctx) != FLB_TRUE) {
+            flb_plg_error(ctx->ins, "unable to delete uncommitted new config");
+            in_calyptia_fleet_destroy(ctx);
+            return -1;
+        }
+        flb_plg_warn(ctx->ins, "deleted uncommitted new config: %s", cfgnewname);
+        flb_sds_destroy(cfgnewname);
+    }
+
     /* if we load a new configuration then we will be reloaded anyways */
     if (load_fleet_config(ctx) == FLB_TRUE) {
         return 0;
-    }
-
-    if (is_fleet_config(ctx, config)) {
-        calyptia_config_commit(ctx);
     }
 
     /* Set our collector based on time */

--- a/src/flb_config.c
+++ b/src/flb_config.c
@@ -307,6 +307,7 @@ struct flb_config *flb_config_init()
     config->hot_reloaded_count = 0;
     config->shutdown_by_hot_reloading = FLB_FALSE;
     config->hot_reloading = FLB_FALSE;
+    config->hot_reload_succeeded = FLB_FALSE;
 
 #ifdef FLB_SYSTEM_WINDOWS
     config->win_maxstdio = 512;

--- a/src/flb_reload.c
+++ b/src/flb_reload.c
@@ -549,6 +549,7 @@ int flb_reload(flb_ctx_t *ctx, struct flb_cf *cf_opts)
     new_config->hot_reloaded_count = reloaded_count;
     flb_debug("[reload] hot reloaded %d time(s)", reloaded_count);
     new_config->hot_reloading = FLB_FALSE;
+    new_config->hot_reload_succeeded = FLB_TRUE;
 
     return 0;
 }


### PR DESCRIPTION
<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
**Problem**
The fleet plugin is buggy today in that it will immediately commit newly received config as the current config, implying the new config is valid. This can notably prevent fluent-bit from restarting correctly after receiving an invalid config.

For example:
* Process starts with a valid config
* Fleet plugin receives a new config. It marks it as current and kicks off a hot reload.
* The hot reload fails. The process will use the old working config.
* Process exits
* Process starts
* Process tries to use the newer invalid config instead of the older valid config.

**Change**

This PR changes how configs received by the fleet plugin are committed as valid.

When a new config is received:
* Any existing new (not current or old) config is deleted, since it is being replaced.
* The received config is saved on disk as new and a hot reload is kicked off.
* Subsequent fleet collect callbacks will check if the hot reload of the new config was successful. If so, the new config is promoted to current.

When a process starts up:
* It deletes new config on disk. By virtue of being marked new, that config was not successfully reloaded in the past.
* It loads up using current or old config, if available.
* It then will attempt to fetch any newer config and reload.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:

- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!--
Please refer to the Developer Guide for instructions on building Fluent Bit with Valgrind support:
https://github.com/fluent/fluent-bit/blob/master/DEVELOPER_GUIDE.md#valgrind
Invoke Fluent Bit and Valgrind as: $ valgrind --leak-check=full ./bin/fluent-bit <args>
-->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.

- [ ] Run [local packaging test](./packaging/local-build-all.sh) showing all targets (including any new ones) build.
- [ ] Set `ok-package-test` label to test for all targets (requires maintainer to do).

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
